### PR TITLE
Remove dependency to pfns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+other/
+
+__pycache__/
+
+*.egg-info/
+
+*.zip
+*.pth
+*.h5
+
+.DS_Store
+
+uv.lock

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ We will release multiple dumps of different scales soon. We also offer an interf
 ### Pretrain your own small nanoTabPFN
 First we download 100k pre-generated datasets with 50 datapoints, 3 features and up to 3  classes each from [here](https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/nanoTabPFN/50x3_3_100k_classification.h5).
 
+or download pre-generated datasets by running:
+```
+python scripts/dumps.py --download
+```
+
 Then you can run:
 ```
 python pretrain_classification.py -epochs 80 -steps 25 -batchsize 50 -priordump 50x3_3_100k_classification.h5

--- a/nanotabpfn/interface.py
+++ b/nanotabpfn/interface.py
@@ -5,7 +5,7 @@ import pandas as pd
 import requests
 import torch
 import torch.nn.functional as F
-from pfns.bar_distribution import FullSupportBarDistribution
+from pfns.model.bar_distribution import FullSupportBarDistribution
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline

--- a/nanotabpfn/interface.py
+++ b/nanotabpfn/interface.py
@@ -5,14 +5,13 @@ import pandas as pd
 import requests
 import torch
 import torch.nn.functional as F
-from pfns.model.bar_distribution import FullSupportBarDistribution
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OrdinalEncoder, FunctionTransformer
 
 from nanotabpfn.model import NanoTabPFNModel
-from nanotabpfn.utils import get_default_device
+from nanotabpfn.utils import FullSupportBarDistribution, get_default_device
 
 
 def init_model_from_state_dict_file(file_path):

--- a/nanotabpfn/train.py
+++ b/nanotabpfn/train.py
@@ -5,12 +5,11 @@ from torch import nn
 import time
 from torch.utils.data import DataLoader
 from typing import Dict
-from pfns.model.bar_distribution import FullSupportBarDistribution
 import schedulefree
 
 from nanotabpfn.callbacks import Callback
 from nanotabpfn.model import NanoTabPFNModel
-from nanotabpfn.utils import get_default_device
+from nanotabpfn.utils import FullSupportBarDistribution, get_default_device
 
 
 def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyLoss | FullSupportBarDistribution,

--- a/nanotabpfn/train.py
+++ b/nanotabpfn/train.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 from torch import nn
 import time
@@ -84,7 +86,9 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                 'model': model.state_dict(),
                 'optimizer': optimizer.state_dict()
             }
-            torch.save(training_state, 'latest_checkpoint.pth')
+
+            os.makedirs('other/checkpoints', exist_ok=True)
+            torch.save(training_state, 'other/checkpoints/latest_checkpoint.pth')
 
             for callback in callbacks:
                 if type(criterion) is FullSupportBarDistribution:

--- a/nanotabpfn/train.py
+++ b/nanotabpfn/train.py
@@ -5,7 +5,7 @@ from torch import nn
 import time
 from torch.utils.data import DataLoader
 from typing import Dict
-from pfns.bar_distribution import FullSupportBarDistribution
+from pfns.model.bar_distribution import FullSupportBarDistribution
 import schedulefree
 
 from nanotabpfn.callbacks import Callback

--- a/nanotabpfn/utils.py
+++ b/nanotabpfn/utils.py
@@ -3,7 +3,6 @@ import random
 import torch
 import numpy as np
 
-from pfns.model.bar_distribution import get_bucket_borders
 
 def set_randomness_seed(seed):
     random.seed(seed)
@@ -15,6 +14,44 @@ def get_default_device():
     if torch.backends.mps.is_available(): device = 'mps'
     if torch.cuda.is_available(): device = 'cuda'
     return device
+
+
+def compute_bucket_borders(num_buckets: int, ys: torch.Tensor) -> torch.Tensor:
+    """
+    decides equal mass bucket borders from ys
+    inspired by pfns.model.bar_distribution get_bucket_borders
+    """
+    ys = torch.as_tensor(ys)
+    if not torch.is_floating_point(ys):
+        ys = ys.to(torch.float32)
+    ys = ys.flatten()
+    ys = ys[torch.isfinite(ys)]
+
+    if ys.numel() <= num_buckets:
+        raise ValueError(f"ys numel ({ys.numel()}) <= num buckets ({num_buckets})")
+
+    n = (ys.numel() // num_buckets) * num_buckets
+    ys = ys[:n]
+    ys_per_bucket = n // num_buckets
+
+    ys_sorted, _ = torch.sort(ys)
+
+    chunks = ys_sorted.reshape(num_buckets, ys_per_bucket)
+    interiors = (chunks[:-1, -1] + chunks[1:, 0]) / 2
+
+    min_outer = ys_sorted[0].unsqueeze(0)
+    max_outer = ys_sorted[-1].unsqueeze(0)
+
+    borders = torch.cat((min_outer, interiors, max_outer))
+
+    if borders.numel() - 1 != num_buckets:
+        raise ValueError("num borders - 1 != num buckets")
+
+    if torch.unique_consecutive(borders).numel() != borders.numel():
+        raise ValueError("duplicate borders detected")
+
+    return borders
+
 
 def make_global_bucket_edges(filename, n_buckets=100, device=get_default_device(), max_y=5_000_000):
     with h5py.File(filename, "r") as f:
@@ -39,5 +76,5 @@ def make_global_bucket_edges(filename, n_buckets=100, device=get_default_device(
         raise ValueError(f"Too few target samples ({ys_concat.size}) to compute {n_buckets} buckets.")
 
     ys_tensor = torch.tensor(ys_concat, dtype=torch.float32, device=device)
-    global_bucket_edges = get_bucket_borders(n_buckets, ys=ys_tensor).to(device)
+    global_bucket_edges = compute_bucket_borders(n_buckets, ys=ys_tensor).to(device)
     return global_bucket_edges

--- a/nanotabpfn/utils.py
+++ b/nanotabpfn/utils.py
@@ -3,7 +3,7 @@ import random
 import torch
 import numpy as np
 
-from pfns.bar_distribution import get_bucket_limits
+from pfns.model.bar_distribution import get_bucket_borders
 
 def set_randomness_seed(seed):
     random.seed(seed)
@@ -39,5 +39,5 @@ def make_global_bucket_edges(filename, n_buckets=100, device=get_default_device(
         raise ValueError(f"Too few target samples ({ys_concat.size}) to compute {n_buckets} buckets.")
 
     ys_tensor = torch.tensor(ys_concat, dtype=torch.float32, device=device)
-    global_bucket_edges = get_bucket_limits(n_buckets, ys=ys_tensor).to(device)
+    global_bucket_edges = get_bucket_borders(n_buckets, ys=ys_tensor).to(device)
     return global_bucket_edges

--- a/nanotabpfn/utils.py
+++ b/nanotabpfn/utils.py
@@ -2,6 +2,7 @@ import h5py
 import random
 import torch
 import numpy as np
+from torch import nn
 
 
 def set_randomness_seed(seed):
@@ -53,7 +54,7 @@ def compute_bucket_borders(num_buckets: int, ys: torch.Tensor) -> torch.Tensor:
     return borders
 
 
-def make_global_bucket_edges(filename, n_buckets=100, device=get_default_device(), max_y=5_000_000):
+def make_global_bucket_borders(filename, n_buckets=100, device=get_default_device(), max_y=5_000_000):
     with h5py.File(filename, "r") as f:
         y = f["y"]
         num_tables, num_datapoints = y.shape
@@ -63,7 +64,7 @@ def make_global_bucket_edges(filename, n_buckets=100, device=get_default_device(
             ys_concat = y[...].reshape(-1)
         else:
             full_rows = max_y // num_datapoints
-            rem =  max_y % num_datapoints
+            rem = max_y % num_datapoints
 
             parts = []
             if full_rows > 0:
@@ -76,5 +77,150 @@ def make_global_bucket_edges(filename, n_buckets=100, device=get_default_device(
         raise ValueError(f"Too few target samples ({ys_concat.size}) to compute {n_buckets} buckets.")
 
     ys_tensor = torch.tensor(ys_concat, dtype=torch.float32, device=device)
-    global_bucket_edges = compute_bucket_borders(n_buckets, ys=ys_tensor).to(device)
-    return global_bucket_edges
+    global_bucket_borders = compute_bucket_borders(n_buckets, ys=ys_tensor).to(device)
+    return global_bucket_borders
+
+
+class BarDistribution(nn.Module):
+    """
+    bar distribution defined by borders with nan target ignoring option
+    inspired by pfns.model.bar_distribution BarDistribution
+    """
+
+    def __init__(self, borders: torch.Tensor, *, ignore_nan_targets: bool = True):
+        super().__init__()
+
+        borders = torch.as_tensor(borders)
+        if borders.ndim != 1:
+            raise ValueError("borders != 1d")
+        if not torch.is_floating_point(borders):
+            borders = borders.to(torch.get_default_dtype())
+        borders = borders.contiguous()
+        self.register_buffer("borders", borders)
+        if torch.any(self.bar_widths <= 0):
+            raise ValueError("borders must be strictly increasing)")
+
+        self.ignore_nan_targets = ignore_nan_targets
+
+    @property
+    def bar_widths(self) -> torch.Tensor:
+        return self.borders[1:] - self.borders[:-1]
+
+    @property
+    def num_bars(self) -> int:
+        return self.borders.numel() - 1
+
+    def ignore_init(self, y: torch.Tensor) -> torch.Tensor:
+        """
+        makes ignore mask for nan targets and alters y (will be ignored later)
+        """
+        ignore_mask = torch.isnan(y)
+        if ignore_mask.any():
+            if not self.ignore_nan_targets:
+                raise ValueError("nan in y while ignore_nan_targets=False")
+            y[ignore_mask] = self.borders[0]
+        return ignore_mask
+
+    def map_to_bar_indices(self, y: torch.Tensor) -> torch.Tensor:
+        """
+        maps each y to its corresponding bar index
+        """
+        indices = torch.searchsorted(self.borders, y, right=False) - 1
+        indices = indices.clamp(0, self.num_bars - 1)
+        return indices
+
+    def compute_scaled_log_probs(self, logits: torch.Tensor) -> torch.Tensor:
+        """
+        log prob density
+        """
+        widths = self.bar_widths.to(logits.device, logits.dtype)
+        log_probs = torch.log_softmax(logits, dim=-1)
+        log_widths = torch.log(widths)
+        scaled_log_probs = log_probs - log_widths
+        return scaled_log_probs
+
+
+class FullSupportBarDistribution(BarDistribution):
+    """
+    extends BarDistribution with half normal tails on both sides for full support
+    inspired by pfns.model.bar_distribution FullSupportBarDistribution
+    """
+
+    def __init__(self, borders: torch.Tensor, *, ignore_nan_targets: bool = True):
+        super().__init__(borders, ignore_nan_targets=ignore_nan_targets)
+        if torch.any(self.bar_widths[[0, -1]] <= 0):
+            raise ValueError("half normal tails need first and last bar widths > 0")
+
+    @staticmethod
+    def halfnormal_with_p_weight_before(desired_quantile_value_at_p: torch.Tensor, p: float = 0.5) -> torch.distributions.HalfNormal:
+        """
+        scales the half normal distribution so that the p weight is before the desired value
+        """
+        device = desired_quantile_value_at_p.device
+        dtype = desired_quantile_value_at_p.dtype
+        standart_halfnormal = torch.distributions.HalfNormal(torch.tensor(1.0, device=device, dtype=dtype))
+        quantile_value_at_p = standart_halfnormal.icdf(torch.tensor(p, device=device, dtype=dtype))
+        scale = desired_quantile_value_at_p / quantile_value_at_p
+        scaled_halfnormal = torch.distributions.HalfNormal(scale)
+        return scaled_halfnormal
+
+    def forward(self, logits: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """
+        negative log likelihood of y given logits
+        """
+        if logits.shape[-1] != self.num_bars:
+            raise ValueError("logits last dimension shape != num bars")
+
+        y = torch.as_tensor(y, device=logits.device, dtype=logits.dtype)
+        y = y.clone().reshape(*logits.shape[:-1])
+
+        ignore_mask = self.ignore_init(y)  # alters y
+
+        y_bar_indices = self.map_to_bar_indices(y)
+
+        scaled_log_probs = self.compute_scaled_log_probs(logits)
+        gathered_scaled_log_probs = scaled_log_probs.gather(-1, y_bar_indices.unsqueeze(-1)).squeeze(-1)
+
+        bar_widths = self.bar_widths.to(logits.device, logits.dtype)
+        borders = self.borders.to(logits.device, logits.dtype)
+        left_tail = self.halfnormal_with_p_weight_before(bar_widths[0])
+        right_tail = self.halfnormal_with_p_weight_before(bar_widths[-1])
+
+        left_mask = y_bar_indices == 0
+        if left_mask.any():
+            distances = (borders[1] - y[left_mask]).clamp(min=1e-8)
+            gathered_scaled_log_probs[left_mask] += left_tail.log_prob(distances) + torch.log(bar_widths[0])
+
+        right_mask = y_bar_indices == self.num_bars - 1
+        if right_mask.any():
+            distances = (y[right_mask] - borders[-2]).clamp(min=1e-8)
+            gathered_scaled_log_probs[right_mask] += right_tail.log_prob(distances) + torch.log(bar_widths[-1])
+
+        nll = -gathered_scaled_log_probs
+
+        if ignore_mask.any():
+            nll[ignore_mask] = 0.0
+
+        return nll
+
+    def mean(self, logits: torch.Tensor) -> torch.Tensor:
+        """
+        calculates the expected value of the distribution given logits
+        """
+        if logits.shape[-1] != self.num_bars:
+            raise ValueError("logits last dimension shape != num bars")
+
+        probs = torch.softmax(logits.to(torch.float32), dim=-1).to(logits.dtype)
+
+        bar_widths = self.bar_widths.to(logits.device, logits.dtype)
+        borders = self.borders.to(logits.device, logits.dtype)
+        left_tail = self.halfnormal_with_p_weight_before(bar_widths[0])
+        right_tail = self.halfnormal_with_p_weight_before(bar_widths[-1])
+
+        bar_means = borders[:-1] + bar_widths / 2
+        bar_means = bar_means.clone()
+        bar_means[0] = borders[1] - left_tail.mean.to(logits.dtype)
+        bar_means[-1] = borders[-2] + right_tail.mean.to(logits.dtype)
+        bar_means = bar_means.to(logits.device, logits.dtype)
+
+        return probs @ bar_means

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import torch
 from sklearn.metrics import accuracy_score
@@ -13,8 +14,8 @@ from nanotabpfn.train import train
 from nanotabpfn.utils import get_default_device, set_randomness_seed
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-priordump", type=str, default="/50x3_3_100k_classification.h5", help="path to the prior dump")
-parser.add_argument("-saveweights", type=str, default="nanotabpfn_weights.pth", help="path to save the trained model to")
+parser.add_argument("-priordump", type=str, default="other/dumps/50x3_3_100k_classification.h5", help="path to the prior dump")
+parser.add_argument("-saveweights", type=str, default="other/model/nanotabpfn_weights.pth", help="path to save the trained model to")
 parser.add_argument("-heads", type=int, default=6, help="number of attention heads")
 parser.add_argument("-embeddingsize", type=int, default=192, help="the size of the embeddings used for the cells")
 parser.add_argument("-hiddensize", type=int, default=768, help="size of the hidden layer of the mlps")
@@ -31,6 +32,9 @@ args = parser.parse_args()
 set_randomness_seed(2402)
 
 device = get_default_device()
+
+os.makedirs(os.path.dirname(args.saveweights), exist_ok=True)
+
 ckpt = None
 if args.loadcheckpoint:
     ckpt = torch.load(args.loadcheckpoint)

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -2,7 +2,6 @@ import argparse
 import os
 
 import torch
-from pfns.model.bar_distribution import FullSupportBarDistribution
 from sklearn.metrics import r2_score
 
 from nanotabpfn.callbacks import ConsoleLoggerCallback
@@ -11,7 +10,12 @@ from nanotabpfn.interface import NanoTabPFNRegressor
 from nanotabpfn.model import NanoTabPFNModel
 from nanotabpfn.priors import PriorDumpDataLoader
 from nanotabpfn.train import train
-from nanotabpfn.utils import get_default_device, set_randomness_seed, make_global_bucket_edges
+from nanotabpfn.utils import (
+    FullSupportBarDistribution,
+    get_default_device,
+    make_global_bucket_borders,
+    set_randomness_seed,
+)
 
 parser = argparse.ArgumentParser()
 
@@ -52,21 +56,21 @@ model = NanoTabPFNModel(
     num_outputs=args.n_buckets,
 )
 
-bucket_edges = make_global_bucket_edges(
+bucket_borders = make_global_bucket_borders(
     filename=args.priordump,
     n_buckets=args.n_buckets,
     device=device,
 )
 
 torch.save(
-    bucket_edges,
+    bucket_borders,
     args.savebuckets,
 )
 
 if ckpt:
     model.load_state_dict(ckpt['model'])
 
-dist = FullSupportBarDistribution(bucket_edges)
+dist = FullSupportBarDistribution(bucket_borders)
 
 class EvaluationLoggerCallback(ConsoleLoggerCallback):
     def __init__(self, tasks):

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -2,7 +2,7 @@ import argparse
 import os
 
 import torch
-from pfns.bar_distribution import FullSupportBarDistribution
+from pfns.model.bar_distribution import FullSupportBarDistribution
 from sklearn.metrics import r2_score
 
 from nanotabpfn.callbacks import ConsoleLoggerCallback

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import torch
 from pfns.bar_distribution import FullSupportBarDistribution
@@ -14,9 +15,9 @@ from nanotabpfn.utils import get_default_device, set_randomness_seed, make_globa
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("-priordump", type=str, default="/50x3_1280k_regression.h5", help="path to the prior dump")
-parser.add_argument("-saveweights", type=str, default="nanotabpfn_weights.pth", help="path to save the trained model to")
-parser.add_argument("-savebuckets", type=str, default="nanotabpfn_buckets.pth", help="path to save the bucket edges to")
+parser.add_argument("-priordump", type=str, default="other/dumps/50x3_1280k_regression.h5", help="path to the prior dump")
+parser.add_argument("-saveweights", type=str, default="other/model/nanotabpfn_weights.pth", help="path to save the trained model to")
+parser.add_argument("-savebuckets", type=str, default="other/model/nanotabpfn_buckets.pth", help="path to save the bucket edges to")
 parser.add_argument("-heads", type=int, default=6, help="number of attention heads")
 parser.add_argument("-embeddingsize", type=int, default=192, help="the size of the embeddings used for the cells")
 parser.add_argument("-hiddensize", type=int, default=768, help="size of the hidden layer of the mlps")
@@ -34,6 +35,9 @@ args = parser.parse_args()
 set_randomness_seed(2402)
 
 device = get_default_device()
+
+os.makedirs(os.path.dirname(args.saveweights), exist_ok=True)
+
 ckpt = None
 if args.loadcheckpoint:
     ckpt = torch.load(args.loadcheckpoint)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "requests>=2",
     "scikit-learn>=1.5",
     "schedulefree>=1.4",
-    "pfns==0.3.0",
+    "pfns==0.4.2",
     "openml==0.15.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
 [project.optional-dependencies]
 wandb = ["wandb>=0.20"]
 tensorboard = ["tensorboard>=2.19"]
+dev = ["pytest>=8.4.2"]
+
 [project.urls]
 Homepage = "https://github.com/PriorLabs/nanoTabPFN"
 Issues = "https://github.com/PriorLabs/nanoTabPFN/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "requests>=2",
     "scikit-learn>=1.5",
     "schedulefree>=1.4",
-    "pfns==0.4.2",
     "openml==0.15.1",
 ]
 

--- a/scripts/dumps.py
+++ b/scripts/dumps.py
@@ -1,0 +1,38 @@
+import argparse
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
+
+DUMPS = {
+    "classification": "https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/nanoTabPFN/50x3_3_100k_classification.h5",
+    "regression": "https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/nanoTabPFN/50x3_1280k_regression.h5",
+}
+TARGET_DIR = Path(__file__).resolve().parents[1] / "other" / "dumps"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--download", choices=list(DUMPS), nargs="*")
+    args = parser.parse_args()
+
+    TARGET_DIR.mkdir(parents=True, exist_ok=True)
+
+    for key in args.download or DUMPS:
+        url = DUMPS[key]
+        dest = TARGET_DIR / Path(urlparse(url).path).name
+        if dest.exists():
+            print(f"already exists, skipping: {dest}")
+            continue
+        try:
+            urlretrieve(url, dest)
+            print(f"saved to: {dest}")
+        except Exception as e:
+            print(f"failed to download {url}: {e}")
+            if dest.exists():
+                dest.unlink()
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import torch
+
+from nanotabpfn.utils import compute_bucket_borders
+
+
+def test_compute_bucket_borders_simple_case():
+    ys = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    ys = torch.tensor(ys, dtype=torch.float32)
+
+    borders = compute_bucket_borders(num_buckets=5, ys=ys)
+
+    expected = torch.tensor([1.0, 2.5, 4.5, 6.5, 8.5, 10.0])
+    torch.testing.assert_close(borders, expected)


### PR DESCRIPTION
First, updated the **pfns** library to the latest version.

Then, implemented custom `BarDistribution`, `FullSupportBarDistribution`, and `compute_bucket_borders`, staying consistent with the original implementation.

We currently don't have NaNs in our training, but I've decided to keep the NaN handling option in BarDistribution.

I tested, and at the end of epochs the losses and average scores are the same as with the original implementation.

I also initialized .gitignore, pytest, and a simple dump downloading script, and made default paths point to `other` directory so that the current working directory stays uncluttered.